### PR TITLE
Re-factored open.js

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -1,7 +1,11 @@
-var exec = require('child_process').exec
-  , path = require('path')
-  ;
-
+var exec = require('child_process').exec, 
+  path = require('path'),
+	platform = {
+		'darwin': 'open',
+		'win32' : 'start ""',
+		'linux' : path.join(__dirname, '../vendor/xdg-open')
+	},
+	opener = platform[ process.platform ] || platform.linux;
 
 /**
  * open a file or uri using the default application for the file type.
@@ -11,31 +15,10 @@ var exec = require('child_process').exec
  * @param {function(Error)} callback - called with null on success, or
  *      an error object that contains a property 'code' with the exit
  *      code of the process.
- */
-
-module.exports = open;
-
-function open(target, callback) {
-  var opener;
-
-  switch (process.platform) {
-  case 'darwin':
-    opener = 'open';
-    break;
-  case 'win32':
-    // if the first parameter to start is quoted, it uses that as the title
-    // so we pass a blank title so we can quote the file we are opening
-    opener = 'start ""';
-    break;
-  default:
-    // use Portlands xdg-open everywhere else
-    opener = path.join(__dirname, '../vendor/xdg-open');
-    break;
-  }
-
-  return exec(opener + ' "' + escape(target) + '"', callback);
-}
-
-function escape(s) {
-  return s.replace(/"/, '\\\"');
-}
+ */	
+module.exports = function open(target, callback) {
+	if(target){
+		target = (''+target).replace(/"/g, '\\\"');
+		return exec(opener + ' "' + target + '"', callback);
+	}
+};

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "author": "J Jordan <jjrdn@styosis.com>",
   "name": "open",
   "description": "open a file or url in the user's preferred application",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/jjrdn/node-open.git"
   },
+  "contributors" : [
+    "Larry Battle (https://github.com/LarryBattle/)"
+  ],
   "homepage": "https://github.com/jjrdn/node-open",
   "bugs": "https://github.com/jjrdn/node-open/issues",
   "main": "lib/open.js",


### PR DESCRIPTION
Update lib/open.js
- Noop if target is falsy.
- Replace all `"` in target.
- Made `opener` a process global constant.
- Used object literal instead of switch cases to set `opener`
- Removed the function escape since it overwrites the default `escape` function.

Update package.json
- Added Larry Battle as a contributor
- Bumped version to 0.0.4
