### PR TITLE
Add optional parameter specifying an application name

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -8,6 +8,8 @@ var exec = require('child_process').exec
  *
  * @return {ChildProcess} - the child process object.
  * @param {string} target - the file/uri to open.
+ * @param {string} appName - (optional) the application to be used to open the
+ *      file (for example, "chrome", "firefox")
  * @param {function(Error)} callback - called with null on success, or
  *      an error object that contains a property 'code' with the exit
  *      code of the process.
@@ -15,21 +17,38 @@ var exec = require('child_process').exec
 
 module.exports = open;
 
-function open(target, callback) {
+function open(target, appName, callback) {
   var opener;
+
+  if (typeof(appName) === 'function') {
+    callback = appName;
+    appName = null;
+  }
 
   switch (process.platform) {
   case 'darwin':
-    opener = 'open';
+    if (appName) {
+      opener = 'open -a "' + escape(appName) + '"';
+    } else {
+      opener = 'open';
+    }
     break;
   case 'win32':
     // if the first parameter to start is quoted, it uses that as the title
     // so we pass a blank title so we can quote the file we are opening
-    opener = 'start ""';
+    if (appName) {
+      opener = 'start "" "' + escape(appName) + '"';
+    } else {
+      opener = 'start ""';
+    }
     break;
   default:
-    // use Portlands xdg-open everywhere else
-    opener = path.join(__dirname, '../vendor/xdg-open');
+    if (appName) {
+      opener = escape(appName);
+    } else {
+      // use Portlands xdg-open everywhere else
+      opener = path.join(__dirname, '../vendor/xdg-open');
+    }
     break;
   }
 

--- a/test/open.js
+++ b/test/open.js
@@ -45,5 +45,8 @@ describe('open', function () {
     open(pathTo('with"quote.html'), done);
   });
 
+  it('should open files in the specified application', function (done) {
+    open(pathTo('with space.html'), 'firefox', done);
+  });
 });
 

--- a/test/support/appname with space.html
+++ b/test/support/appname with space.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+  <h1>open.js test asset</h1>
+  <p>If this page is opened in Firefox, the test might have worked. If you don't have Firefox configured as your default browser, it definitely worked! You can close this.</p>
+</html>


### PR DESCRIPTION
Thank you very much for `node-open`!

I use it to open a browser window to run my library's integration tests.

Everything works perfectly, until I want to use a non-default browser to run my tests. I did a bit of research, and added support for specifying an optional application name in `open`, like this:

``` javascript
open('http://google.com', 'firefox');
```

I hope you will consider merging this patch! Thank you for making my life easier with `node-open`!
