### PR TITLE
launch browser as original user if run from sudo

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -52,6 +52,9 @@ function open(target, appName, callback) {
     break;
   }
 
+  if (process.env.SUDO_USER) {
+    opener = 'sudo -u ' + process.env.SUDO_USER + ' ' + opener;
+  }
   return exec(opener + ' "' + escape(target) + '"', callback);
 }
 

--- a/test/open.js
+++ b/test/open.js
@@ -9,6 +9,9 @@ var open = require('../');
 // does not return an error, and this is a good proxy for success for
 // much less effort.
 //
+// this test should be run with both 'npm test' and 'sudo npm test' to make
+// sure the application is opened in user context even during sudo
+//
 // the xdg-open script behaves differently than start and open in that
 // it does not return after opening the process, it waits until the child
 // process exits.  Because of this, the callback parameter is not documented


### PR DESCRIPTION
When running the node application using 'sudo' on mac, Safari was opened instead of the user's default browser. This PR tests the SUDO_USER environment variable to see if we are during sudo, and if so, runs the command with the original user context. This fixes issue #4.
