### PR TITLE
Accept wildcard in path

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -52,7 +52,7 @@ function open(target, appName, callback) {
     break;
   }
 
-  return exec(opener + ' "' + escape(target) + '"', callback);
+  return exec(opener + ' ' + escape(target), callback);
 }
 
 function escape(s) {


### PR DESCRIPTION
Using double quotes around the given path makes that paths using wildcards like:

```
open "path/to/my/file/*/file.html"
```

don't work. Given an error `"File does not exist"`

Just by removing those quotes, open works correct with wildcards, as it does from a terminal

```
open path/to/my/file/*/file.html
```

even

```
open "Google Chrome" path/to/my/file/*/file.html
```
