### PR TITLE
Open now handles paths with blank space in them

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -48,6 +48,7 @@ function open(target, appName, callback) {
     } else {
       // use Portlands xdg-open everywhere else
       opener = path.join(__dirname, '../vendor/xdg-open');
+      opener = opener.replace(new RegExp(" ","gm"), "\\ ");
     }
     break;
   }


### PR DESCRIPTION
On Linux open failes when it tries to open a path that contains a blank space. "/home/user/app/my app"
With Command failed: /bin/sh: 1: /home/user/app/my: not found.
I added a line replacing blank space characters with '\ ' which makes it work.
