### PR TITLE
use system xdg-open if exists

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec
   , path = require('path')
+  , whereis = require('node-whereis')
   ;
 
 
@@ -45,6 +46,9 @@ function open(target, appName, callback) {
   default:
     if (appName) {
       opener = escape(appName);
+    } else if (whereis('xdg-open')) {
+        // use default xdg-open if exist
+        opener = 'xdg-open';
     } else {
       // use Portlands xdg-open everywhere else
       opener = path.join(__dirname, '../vendor/xdg-open');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "open",
   "version": "0.0.5",
   "description": "open a file or url in the user's preferred application",
-  "keywords": ["start", "open", "browser", "editor", "default"],
+  "keywords": [
+    "start",
+    "open",
+    "browser",
+    "editor",
+    "default"
+  ],
   "homepage": "https://github.com/jjrdn/node-open",
   "author": "J Jordan <jjrdn@styosis.com>",
   "license": "MIT",
@@ -19,7 +25,9 @@
   "engines": {
     "node": ">= 0.6.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-whereis": "0.0.1"
+  },
   "devDependencies": {
     "mocha": "*"
   },


### PR DESCRIPTION
on  debian the xdg-open local script doesnt work properly
neither the last official version http://portland.freedesktop.org/xdg-utils-1.1.0-rc1/scripts/xdg-open
I think if it exist on the system we should use this one first
