### PR TITLE
Reveal and select target on desktop

### DIFF
--- a/lib/open.js
+++ b/lib/open.js
@@ -25,10 +25,20 @@ function open(target, appName, callback) {
     appName = null;
   }
 
+  var openInDesktop =
+    appName &&
+    (appName.toLowerCase() === 'finder' ||
+    appName.toLowerCase() === 'explorer' ||
+    appName.toLowerCase() === 'desktop');
+
   switch (process.platform) {
   case 'darwin':
     if (appName) {
-      opener = 'open -a "' + escape(appName) + '"';
+      if (openInDesktop) {
+        opener = 'open -R ';
+      } else {
+        opener = 'open -a "' + escape(appName) + '"';
+      }
     } else {
       opener = 'open';
     }
@@ -37,7 +47,12 @@ function open(target, appName, callback) {
     // if the first parameter to start is quoted, it uses that as the title
     // so we pass a blank title so we can quote the file we are opening
     if (appName) {
-      opener = 'start "" "' + escape(appName) + '"';
+      if (openInDesktop) {
+        opener = 'Explorer /select,';
+        return exec(opener + '"' + escape(target) + '"', callback);
+      } else {
+        opener = 'start "" "' + escape(appName) + '"';
+      }
     } else {
       opener = 'start ""';
     }

--- a/test/open.js
+++ b/test/open.js
@@ -51,5 +51,9 @@ describe('open', function () {
   it('should open files in the specified application', function (done) {
     open(pathTo('with space.html'), 'firefox', done);
   });
+
+  it('should open a window on the desktop and select the specified file', function(done) {
+    open(pathTo('asset.txt'), 'desktop', done);
+  });
 });
 


### PR DESCRIPTION
When appName is ‘finder’, ‘explorer’, or ‘desktop’, open a window on the desktop to the containing folder and select the target instead of opening the target file. Currently only handled on Mac and Windows.
