### PR TITLE
bin script version to allow open to be used in npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open a file or url in the user's preferred application.
 
-# Usage
+# Node usage
 
 ```javascript
 var open = require("open");
@@ -14,6 +14,20 @@ file or URL.
 
 ```javascript
 open("http://www.google.com", "firefox");
+```
+
+# NPM script usage
+
+```javascript
+{ ...
+  "scripts: {
+    ...
+    "browser": "node-open http://www.google.com",
+    "firefox": "node-open http://www.google.com firefox",
+    ...
+  },
+  ...
+}
 ```
 
 # Installation

--- a/bin/open
+++ b/bin/open
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+var open = require('../lib/open');
+var url = process.argv[2];
+var browser = process.argv[3];
+open(url, browser);

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "open",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "open a file or url in the user's preferred application",
-  "keywords": ["start", "open", "browser", "editor", "default"],
+  "keywords": [
+    "start",
+    "open",
+    "browser",
+    "editor",
+    "default"
+  ],
   "homepage": "https://github.com/jjrdn/node-open",
   "author": "J Jordan <jjrdn@styosis.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "optionalDependencies": {},
   "main": "lib/open.js",
+  "bin": {
+    "node-open": "bin/open"
+  },
   "scripts": {
     "test": "node_modules/mocha/bin/mocha"
   }

--- a/test/support/with"quote.html
+++ b/test/support/with"quote.html
@@ -1,5 +1,0 @@
-<!doctype html>
-<html>
-  <h1>open.js test asset</h1>
-  <p>If this is your default browser, it worked. You can close this.</p>
-</html>


### PR DESCRIPTION
As different OS have different calls, being able to rely on `open` to open URLs in browsers cross-platform when using npm scripts feels like a valuable improvement.

This PR sets up a CLI command `node-open` (so as not to conflict with preexisting `open` commands on OS that come with that) that can be used in npm scripts (or the general command line if someone installs open with `-g`, which would be odd =) to open urls in browsers for testing purposes.

I already use this myself for testing a combination client/server game codebase, where neither the server nor client should open a browser by default, but `npm run webtest` will call an npm-run-all instruction that starts the server task, the client task, and an `node-open http://localhost:8081/client firefox` because holy crap is that convenient.
